### PR TITLE
fix docker volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     user: vortex
     privileged: true
     volumes:
-      - ".:/home/vortex/asv_ws/src" # Shared volume to avoid rebuilding when starting a new container
+      - ".:/home/vortex/asv_ws/src/Vortex-ASV" # Shared volume to avoid rebuilding when starting a new container
+      - "/dev:/dev"
     environment:
       DISPLAY: :0
     stdin_open: true


### PR DESCRIPTION
This fix makes it so that the Vortex-ASV files are added to  src/Vortex-ASV in the docker container. Additionally it adds /dev as a shared volume so that we can fetch data from serial devices like the STIM300.