### PR TITLE
Feature/rtab slam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN echo "vortex:vortex" | chpasswd
 RUN usermod -aG sudo vortex
 
 
-
 # ROS package dependencies
 RUN apt update && \
     apt install -y \
@@ -22,8 +21,12 @@ RUN apt update && \
     libeigen3-dev \
     ros-$distro-joy \
     ros-$distro-tf2-geometry-msgs \
+    ros-$distro-geographic-msgs \
     ros-$distro-pcl-ros \
     ros-$distro-rviz \
+    ros-$distro-rtabmap \
+    ros-$distro-rtabmap-ros \
+    ros-noetic-imu-tools \
     libeigen3-dev \
     libglfw3-dev \
     libglew-dev \

--- a/asv_setup/launch/lidar_slam.launch
+++ b/asv_setup/launch/lidar_slam.launch
@@ -1,0 +1,125 @@
+
+<launch>
+  
+    <!-- 
+    Hand-held 3D lidar mapping example using only a Ouster OS-1 (no camera).
+    Prerequisities: rtabmap should be built with libpointmatcher
+    Example:
+     $ roslaunch rtabmap_ros test_ouster.launch os1_hostname:=os1-XXXXXXXXXXXX.local os1_udp_dest:=192.168.1.XXX
+     $ rosrun rviz rviz -f map
+     $ Show TF and /rtabmap/cloud_map topics
+    ISSUE: You may have to reset odometry after receiving the first cloud if the map looks tilted. The problem seems 
+           coming from the first cloud sent by os1_cloud_node, which may be poorly synchronized with IMU data.
+    -->
+
+    <!-- Required: -->
+    <arg name="sensor_hostname"/>
+
+    <arg name="frame_id" default="os_sensor"/>
+    <arg name="rtabmapviz"    default="true"/>
+    <arg name="scan_20_hz"    default="true"/>
+    <arg name="use_sim_time"  default="false"/>
+    <param if="$(arg use_sim_time)" name="use_sim_time" value="false"/>
+    
+    <!-- Ouster -->
+    <remap unless="$(arg use_sim_time)" from="/os_cloud_node/imu" to="/os_cloud_node/imu/data_raw"/>
+    <include unless="$(arg use_sim_time)" file="$(find ouster_ros)/ouster.launch">
+      <arg name="sensor_hostname" value="$(arg sensor_hostname)"/>
+      <arg name="metadata" value="/home/vortex/metadata"/>
+    </include>
+
+    <!-- IMU orientation estimation and publish tf accordingly to os1_sensor frame -->
+    <node pkg="nodelet" type="nodelet" name="imu_nodelet_manager" args="manager">
+      <remap from="imu" to="/os_cloud_node/imu"/>
+    </node>
+    <node pkg="nodelet" type="nodelet" name="imu_filter" args="load imu_filter_madgwick/ImuFilterNodelet imu_nodelet_manager">
+      <param name="use_mag" value="false"/>
+      <param name="world_frame" value="enu"/>
+      <param name="publish_tf" value="false"/>
+    </node> 
+    <node pkg="nodelet" type="nodelet" name="imu_to_tf" args="load rtabmap_ros/imu_to_tf imu_nodelet_manager">
+      <remap from="imu/data" to="/os_cloud_node/imu/data"/>
+      <param name="fixed_frame_id" value="$(arg frame_id)_stabilized"/>
+      <param name="base_frame_id" value="$(arg frame_id)"/>
+    </node> 
+
+    <group ns="rtabmap">
+      <node pkg="rtabmap_ros" type="icp_odometry" name="icp_odometry" output="screen">
+        <remap from="scan_cloud" to="/os_cloud_node/points"/>
+        <param name="frame_id"        type="string" value="$(arg frame_id)"/>  
+        <param name="odom_frame_id"   type="string" value="odom"/>
+        <param     if="$(arg scan_20_hz)" name="expected_update_rate" type="double" value="25"/>
+        <param unless="$(arg scan_20_hz)" name="expected_update_rate" type="double" value="15"/>
+
+        <remap from="imu" to="/os_cloud_node/imu/data"/>
+        <param name="guess_frame_id"   type="string" value="$(arg frame_id)_stabilized"/>
+        <param name="wait_imu_to_init" type="bool" value="true"/>
+     
+        <!-- ICP parameters -->
+        <param name="Icp/PointToPlane"        type="string" value="true"/>
+        <param name="Icp/Iterations"          type="string" value="10"/>
+        <param name="Icp/VoxelSize"           type="string" value="0.2"/>
+        <param name="Icp/DownsamplingStep"    type="string" value="1"/> <!-- cannot be increased with ring-like lidar -->
+        <param name="Icp/Epsilon"             type="string" value="0.001"/>
+        <param name="Icp/PointToPlaneK"       type="string" value="20"/>
+        <param name="Icp/PointToPlaneRadius"  type="string" value="0"/>
+        <param name="Icp/MaxTranslation"      type="string" value="2"/>
+        <param name="Icp/MaxCorrespondenceDistance" type="string" value="1"/>
+        <param name="Icp/PM"                  type="string" value="true"/> 
+        <param name="Icp/PMOutlierRatio"      type="string" value="0.1"/>
+        <param name="Icp/CorrespondenceRatio" type="string" value="0.01"/>  
+
+        <!-- Odom parameters -->       
+        <param name="Odom/ScanKeyFrameThr"       type="string" value="0.95"/>
+        <param name="Odom/Strategy"              type="string" value="0"/>
+        <param name="OdomF2M/ScanSubtractRadius" type="string" value="0.2"/>
+        <param name="OdomF2M/ScanMaxSize"        type="string" value="15000"/>      
+      </node>
+
+      <node pkg="rtabmap_ros" type="rtabmap" name="rtabmap" output="screen" args="-d">	  
+        <param name="frame_id"             type="string" value="$(arg frame_id)"/>  
+        <param name="subscribe_depth"      type="bool" value="false"/>
+        <param name="subscribe_rgb"        type="bool" value="false"/>
+        <param name="subscribe_scan_cloud" type="bool" value="true"/>
+        <param name="approx_sync"          type="bool" value="false"/>
+        
+        <remap from="scan_cloud" to="/os_cloud_node/points"/>
+        <remap from="imu" to="/os_cloud_node/imu/data"/>
+     
+        <!-- RTAB-Map's parameters -->
+        <param name="Rtabmap/DetectionRate"          type="string" value="1"/>  
+        <param name="RGBD/NeighborLinkRefining"      type="string" value="false"/>
+        <param name="RGBD/ProximityBySpace"          type="string" value="true"/>
+        <param name="RGBD/ProximityMaxGraphDepth"    type="string" value="0"/>
+        <param name="RGBD/ProximityPathMaxNeighbors" type="string" value="1"/>
+        <param name="RGBD/AngularUpdate"             type="string" value="0.05"/>
+        <param name="RGBD/LinearUpdate"              type="string" value="0.05"/>
+        <param name="Mem/NotLinkedNodesKept"         type="string" value="false"/>
+        <param name="Mem/STMSize"                    type="string" value="30"/>
+        <!-- param name="Mem/LaserScanVoxelSize"     type="string" value="0.1"/ -->
+        <!-- param name="Mem/LaserScanNormalK"       type="string" value="10"/ -->
+        <!-- param name="Mem/LaserScanRadius"        type="string" value="0"/ -->
+        
+        <param name="Reg/Strategy"                   type="string" value="1"/> 
+        <param name="Grid/CellSize"                  type="string" value="0.1"/>
+        <param name="Grid/RangeMax"                  type="string" value="20"/>
+        <param name="Grid/ClusterRadius"             type="string" value="1"/>
+        <param name="Grid/GroundIsObstacle"          type="string" value="true"/>
+        <param name="Optimizer/GravitySigma"         type="string" value="0.3"/>
+
+        <!-- ICP parameters -->
+        <param name="Icp/VoxelSize"                  type="string" value="0.3"/>
+        <param name="Icp/PointToPlaneK"              type="string" value="20"/>
+        <param name="Icp/PointToPlaneRadius"         type="string" value="0"/>
+        <param name="Icp/PointToPlane"               type="string" value="false"/>
+        <param name="Icp/Iterations"                 type="string" value="10"/>
+        <param name="Icp/Epsilon"                    type="string" value="0.001"/>
+        <param name="Icp/MaxTranslation"             type="string" value="3"/>
+        <param name="Icp/MaxCorrespondenceDistance"  type="string" value="1"/>
+        <param name="Icp/PM"                         type="string" value="true"/> 
+        <param name="Icp/PMOutlierRatio"             type="string" value="0.7"/>
+        <param name="Icp/CorrespondenceRatio"        type="string" value="0.4"/>
+      </node>
+  </group>
+
+</launch>


### PR DESCRIPTION
RTAB SLAM is now added to the container. Added a launchfile for lidar+imu SLAM. Can expand to VI-SLAM whenever.

Because of how easy RTAB is to use, this will be the go-to mapping package over WOLF for the time being.

Pictures from the office:

Probabalistic 2D occupancy map:
![prob_2d_map](https://user-images.githubusercontent.com/48532094/153479610-dcbf5fdd-d88f-4d18-9223-2d3d2232a7f5.png)

The corresponding 3D pointcloud, seen from above:
![pcl](https://user-images.githubusercontent.com/48532094/153479619-04c01824-35b9-4b6f-8784-488a6a6285c7.png)

