### PR TITLE
changed vortex_msgs to std_msgs in package.xml

### DIFF
--- a/motion/thruster_allocator/package.xml
+++ b/motion/thruster_allocator/package.xml
@@ -9,7 +9,7 @@
 
   <depend>rclcpp</depend>
   <depend>geometry_msgs</depend>
-  <depend>vortex_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>eigen</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
As vortex_msgs is no longer used in thruster_allocator it should be switched out with std_msgs in package.xml for the use of Float32MultiArray